### PR TITLE
Make ExperimentDataRoleBlueprint optional

### DIFF
--- a/fid-trace.atdd
+++ b/fid-trace.atdd
@@ -5,7 +5,7 @@
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="urn:org:astm:animl:schema:technique:draft:0.90 http://schemas.animl.org/current/animl-technique.xsd">
     <Documentation>Technique definition for Flame Ionization Point Detector data</Documentation>
-    <ExperimentDataRoleBlueprint name="Data Source" experimentStepPurpose="consumed">
+    <ExperimentDataRoleBlueprint name="Data Source" experimentStepPurpose="consumed" modality="optional">
         <Documentation>Reference to the GC separation experiment step.</Documentation>
     </ExperimentDataRoleBlueprint>
     <MethodBlueprint>


### PR DESCRIPTION
Especially when converting vendor-specific data format it is not always possible to get the full rich set of data that the GC separation experiment step would require here.
Of course one could try to create a dummy Step and fill it with some dummy data, but this gives the false expression the information is/was really available and could give strange results if displayed in a viewer because mandatory fields contains values that do not make much sens to an experienced user.

I'd like therefore suggest to make the ExperimentDataRoleBlueprint `Data Source` optional.