### PR TITLE
chromatography-peak-table: Fix lineendings, fix wrong property value

### DIFF
--- a/chromatography-peak-table.atdd
+++ b/chromatography-peak-table.atdd
@@ -767,7 +767,7 @@
                 <Documentation>This is a textual description of the type of a peak's shape or other  properties (e.g. a shoulder or skimmed).
                 </Documentation>
             </SeriesBlueprint>
-            <SeriesBlueprint name="Peak Number ISTD" seriesType="Int" modality="optional" dependency="dependency">
+            <SeriesBlueprint name="Peak Number ISTD" seriesType="Int" modality="optional" dependency="dependent">
                 <Documentation>The number of the peak used as an internal standard.</Documentation>
             </SeriesBlueprint>
             <SeriesBlueprint name="Assignment ID" seriesType="String" modality="optional" plotScale="none"

--- a/chromatography-peak-table.atdd
+++ b/chromatography-peak-table.atdd
@@ -1,1 +1,836 @@
-<?xml version="1.0" encoding="UTF-8"?>        <!-- edited by Patrick Boba(BSSN Software) -->        <!DOCTYPE Technique SYSTEM "animl_unit_entities.dtd"><Technique name="Chromatography Peak Table" version="0.90" xmlns="urn:org:astm:animl:schema:technique:draft:0.90"           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"           xsi:schemaLocation="urn:org:astm:animl:schema:technique:draft:0.90 http://schemas.animl.org/current/animl-technique.xsd">    <Documentation>Peak table technique definition for a LC/GC time trace.</Documentation>    <ExperimentDataRoleBlueprint name="Calibration Table" experimentStepPurpose="consumed" modality="optional">        <Documentation>Calibration table with the results from related calibration runs.</Documentation>    </ExperimentDataRoleBlueprint>    <ExperimentDataRoleBlueprint name="Data Source" experimentStepPurpose="consumed" modality="optional">        <Documentation>Chromatogram from which this peak table was generated.</Documentation>    </ExperimentDataRoleBlueprint>    <MethodBlueprint>        <CategoryBlueprint name="Instrument Settings" modality="optional">            <Documentation>Variable characteristics or configuration parameters of the instrument.</Documentation>            <ParameterBlueprint name="Detector Offset" parameterType="Numeric" maxOccurs="1" modality="optional">                <Quantity name="time">                    &min; &s; &ms;                </Quantity>            </ParameterBlueprint>        </CategoryBlueprint>        <CategoryBlueprint name="Peak Detection" modality="optional">            <Documentation>Details on the used peak finding algorithm.</Documentation>            <ParameterBlueprint name="Algorithm Name" parameterType="String" modality="required">                <Documentation>The common name for the used algorithm.</Documentation>            </ParameterBlueprint>            <CategoryBlueprint name="Algorithm Parameters" modality="optional">                <Documentation>This section has to be handled by a vendor specific TechniqueExtension.</Documentation>            </CategoryBlueprint>        </CategoryBlueprint>        <CategoryBlueprint name="Baseline Detection" modality="optional">            <Documentation>Details on the used baseline detection algorithm.</Documentation>            <ParameterBlueprint name="Algorithm Name" parameterType="String" modality="required">                <Documentation>The common name for the used algorithm.</Documentation>            </ParameterBlueprint>            <CategoryBlueprint name="Algorithm Parameters" modality="optional">                <Documentation>This section has to be handled by a vendor specific TechniqueExtension.</Documentation>            </CategoryBlueprint>            <!-- is there a way to collect information on the baseline detection algorithm's parameters? -->        </CategoryBlueprint>        <CategoryBlueprint name="Peak Integration" modality="optional">            <Documentation>Details on the how the peak integration was performed.</Documentation>            <CategoryBlueprint name="Integration Algorithm" modality="optional">                <Documentation>The used integration algorithm.</Documentation>                <ParameterBlueprint name="Algorithm Name" parameterType="String">                    <Documentation>The common name for the used algorithm.</Documentation>                </ParameterBlueprint>                <CategoryBlueprint name="Algorithm Parameters" modality="optional">                    <Documentation>This section has to be handled by a vendor specific TechniqueExtension.                    </Documentation>                </CategoryBlueprint>            </CategoryBlueprint>            <CategoryBlueprint name="Skimming Algorithm" modality="optional">                <Documentation>If applicable, the used skimming algorithm.</Documentation>                <ParameterBlueprint name="Algorithm Name" parameterType="String" modality="required">                    <AllowedValue>                        <S>None</S>                    </AllowedValue>                    <AllowedValue>                        <S>Tangential</S>                    </AllowedValue>                    <AllowedValue>                        <S>Exponential</S>                    </AllowedValue>                    <AllowedValue>                        <S>Gaussian</S>                    </AllowedValue>                    <AllowedValue>                        <S>Valley to Valley</S>                    </AllowedValue>                    <AllowedValue>                        <S>Vertical Drop</S>                    </AllowedValue>                    <AllowedValue>                        <S>Other</S>                    </AllowedValue>                </ParameterBlueprint>                <CategoryBlueprint name="Algorithm Parameters" modality="optional">                    <Documentation>This section has to be handled by a vendor specific TechniqueExtension.                    </Documentation>                </CategoryBlueprint>            </CategoryBlueprint>        </CategoryBlueprint>        <CategoryBlueprint name="Filtering" modality="optional" maxOccurs="unbounded">            <Documentation>Filtering Step that was applied to the chromatogram prior to peak detection (e.g. smoothing                filters).            </Documentation>            <ParameterBlueprint name="Algorithm Name" parameterType="String" modality="required">                <Documentation>Details on the used filtering algorithm.</Documentation>            </ParameterBlueprint>            <CategoryBlueprint name="Algorithm Parameters" modality="optional">                <Documentation>This section has to be handled by a vendor specific TechniqueExtension.</Documentation>            </CategoryBlueprint>        </CategoryBlueprint>    </MethodBlueprint>    <ResultBlueprint name="Peak Table">        <SeriesSetBlueprint name="Peak Table">            <Documentation literatureReferenceID="USP 621 Chromatography">USP: "A peak is the portion of the                chromatographic                recording of the detector response when a single component                is eluted from the column. If separation is incomplete,                two or more components may be eluted as one unresolved peak." A peak table is a collection of peaks as                described before.            </Documentation>            <SeriesBlueprint name="Number" seriesType="Int" modality="required" dependency="independent"                             plotScale="none">                <Documentation literatureReferenceID="ASTM E1947-98">Peak number identifying this particular peak. This                    is a running number.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="ID" seriesType="String" modality="optional" dependency="dependent" plotScale="none">                <Documentation literatureReferenceID="ASTM E1947-98">Peak identifier for this particular peak. This ID                    may be generated by the originating data system.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Group ID" seriesType="String" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>Identifier to assign a peak to a peak group along different detector channels of a single                    injection.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Name" seriesType="String" dependency="dependent" plotScale="none" maxOccurs="1" modality="optional">                <Documentation>A descriptive name of the peak (e.g. "Solvent Peak", "Target Substance", etc.).</Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Retention Time" seriesType="Numeric" modality="required" plotScale="none"                             dependency="dependent">                <Documentation literatureReferenceID="IUPAC Gold Book">Position on x axis where the peak maximum                    appears.                </Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Adjusted Retention Time" seriesType="Numeric" modality="optional" plotScale="none"                             dependency="dependent">                <Documentation literatureReferenceID="USP 621 Chromatography">Adjusted retention time of a component                    relative to that of another used as a reference.                </Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Start Time" seriesType="Numeric" modality="optional" plotScale="none"                             dependency="dependent">                <Documentation>Beginning of a peak</Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="End Time" seriesType="Numeric" modality="optional" plotScale="none"                             dependency="dependent">                <Documentation>End of a peak.</Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Value" seriesType="Numeric" modality="required" dependency="dependent"                             plotScale="none">                <Documentation>The peak's intensity at the peak apex.</Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Start Value" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>The peak's intensity at the peak start time.</Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="End Value" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>The peak's intensity at the peak end time.</Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Inflection Point Front Time" seriesType="Numeric" dependency="dependent"                             modality="optional" plotScale="none">                <Documentation>The x-coordinate of the inflection point of the front side of the peak.</Documentation>                <Quantity name="time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Inflection Point Front Value" seriesType="Numeric" dependency="dependent"                             modality="optional" plotScale="none">                <Documentation>The y-coordinate (= intensity) of the inflection point of the front side of the peak.                </Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Inflection Point Rear Time" seriesType="Numeric" dependency="dependent"                             modality="optional" plotScale="none">                <Documentation>The x-coordinate of the inflection point of the rear side of the peak.</Documentation>                <Quantity name="time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Inflection Point Rear Value" seriesType="Numeric" dependency="dependent"                             modality="optional" plotScale="none">                <Documentation>The y-coordinate (= intensity) of the inflection point of the rear side of the peak.                </Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Baseline Start Time" seriesType="Numeric" modality="optional" plotScale="none"                             dependency="dependent" maxOccurs="1">                <Documentation>Beginning of the baseline of a peak</Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Baseline Start Value" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none" maxOccurs="1">                <Documentation literatureReferenceID="ASTM E1947-98">Starting value (= intensity) of the computed                    baseline for this                    peak; in a scaled data unit, the unit for this is the same as that of the ordinate variable.                </Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Baseline End Time" seriesType="Numeric" modality="optional" plotScale="none"                             dependency="dependent" maxOccurs="1">                <Documentation>End of the baseline of a peak.</Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Baseline End Value" seriesType="Numeric" modality="optional" dependency="dependent"                             maxOccurs="1" plotScale="none">                <Documentation literatureReferenceID="ASTM E1947-98">End value (= intensity) of the computed baseline                    for this                    peak; in a scaled data unit, the unit for this is the same as that of the ordinate variable.                </Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Width Half Height" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="IUPAC Gold Book">Peak width at half height (w_h).</Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Width Base" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="IUPAC Gold Book">Peak width at base (w_b) is the segment of the                    peak base intercepted by the tangents drawn to the inflection points on either side of the peak.                </Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Width Inflection Point" seriesType="Numeric" modality="optional"                             dependency="dependent" plotScale="none">                <Documentation literatureReferenceID="IUPAC Gold Book">Peak width at inflection points (w_i) is the                    length of the line drawn between the inflection points parallel to the peak base.                </Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Width at 5% Height" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>Peak width at 5% relative height of the peak.</Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Width at 10% Height" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>Peak width at 10% relative height of the peak.</Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Height" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="IUPAC Gold Book">The distance between the peak maximum and the                    peak base, measured in a direction parallel to the axis representing the detector response. Can be                    either absolute or relative with respect to all peaks noted here.                </Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Height Percent" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>The distance between the peak maximum and the peak base, measured in a direction parallel                    to the axis representing the detector response relative to all detected peaks.                </Documentation>                <Quantity name="Percent Intensity">                    &percent;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Height-To-Valley Front" seriesType="Numeric" modality="optional"                             dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="USP 621 Chromatography">The distance between the peak maximum and                    the valley to the left side of the apex, measured in a direction parallel                    to the axis representing the detector response. Can be either absolute or relative with respect to                    all peaks noted here                </Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Height-To-Valley Rear" seriesType="Numeric" modality="optional"                             dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="USP 621 Chromatography">The distance between the peak maximum and                    the valley to the right side of the apex, measured in a direction parallel                    to the axis representing the detector response. Can be either absolute or relative with respect to                    all peaks noted here                </Documentation>                <Quantity name="Intensity">                    &A; &AU;                </Quantity>                <Quantity name="Counts">                    &counts;                </Quantity>                <Quantity name="Voltage">                    &mV;                </Quantity>                <Quantity name="Percent">                    &percent;                </Quantity>                <Quantity name="Absorbance">                    &A; &AU;                </Quantity>                <Quantity name="Transmittance">                    &T; &percentT;                </Quantity>                <Quantity name="Reflectance">                    &R; &percentR;                </Quantity>                <Quantity name="Arbitrary">                    &arbitrary;                </Quantity>                <Quantity name="Custom">                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Mean Retention Time" seriesType="Numeric" modality="optional" plotScale="none"                             dependency="dependent">                <Documentation>The center of gravity of a peak. This is not necessarily the same as the retention time,                    depending on the skewness of the peak.                </Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Relative Retention Time" seriesType="Numeric" modality="optional" plotScale="none"                             dependency="dependent">                <Documentation literatureReferenceID="USP 621 Chromatography">USP: "Also known as unadjusted relative                    retention. Comparisons in USP are normally                    made in terms of unadjusted relative retention, unless otherwise indicated."                </Documentation>                <Quantity name="Time">                    &min;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Relative Retention" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="USP 621 Chromatography">                    USP: "Is the ratio of the adjusted retention time of a component relative to that of another used as                    a reference under identical conditions.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Separation Factor" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="USP 621 Chromatography">                    USP: "The separation factor is the relative retention calculated for two adjacent peaks (by                    convention the value of the separation factor is always bigger then 1.)"                </Documentation>                <Quantity name="alpha">                    <Unit label='alpha'>                        <SIUnit exponent='1' factor='1'>1</SIUnit>                    </Unit>                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Retention Factor" seriesType="Numeric" dependency="dependent" modality="optional"                             plotScale="none">                <Documentation literatureReferenceID="Nomenclature for Chromatography">The retention factor k = (T_r -                    T_0) / T_0. T_r is the retention time of the peak and T_0 the void time. Maybe also termed 'Capacity                    Factor', 'Capacity Ratio', 'Retention Ratio' or 'Mass Distribution'.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Retention Volume" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="IUPAC Gold Book">Retention measurements (and measurements of                    hold-up volume and peak width) may be made in terms of times or chart distances as well as volumes.                    If flow and recorder speeds are constant, the volumes are directly proportional to the times and                    chart distances.                </Documentation>                <Quantity name="Volume">                    &mL;                </Quantity>            </SeriesBlueprint>            <!-- Unit for Area unclear. It depends on the units of the chromatogram. -->            <SeriesBlueprint name="Area" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="ASTM E1947-98">The area enclosed between the peak and the                    baseline.                </Documentation>                <Quantity name="Area">                    &arbitrary;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Area Corrected" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>The peak area after a correction like skimming or function fitting was performed.                </Documentation>                <Quantity name="Area">                    &arbitrary;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Area Percent" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="ASTM E1947-98">The area enclosed between the peak and the                    baseline. Can be either absolute or relative with respect to all peaks noted here                </Documentation>                <Quantity name="Area">                    &percent;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Amount" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>The amount is the area percent of the peak with respect to the injected volume or concentration.                </Documentation>                <Quantity name="Amount">                    &mg_per_mL;                    &mL_per_mL;                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Plate Number Half-Height" seriesType="Numeric" modality="optional"                             dependency="dependent" plotScale="none">                <Documentation literatureReferenceID="Nomenclature for Chromatography">The number of theoretical Plates                    per column using the half-width method (ASTM).                </Documentation>                <Quantity name="Plate Number">                    <Unit label="n">                        <SIUnit factor="1" exponent="-1">1</SIUnit>                    </Unit>                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Plate Number Base" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="Nomenclature for Chromatography">The number of theoretical Plates                    per column using the tangent method (USP, ASTM).                </Documentation>                <Quantity name="Plate Number">                    <Unit label="n">                        <SIUnit factor="1" exponent="-1">1</SIUnit>                    </Unit>                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Plate Number Variance" seriesType="Numeric" modality="optional"                             dependency="dependent" plotScale="none">                <Documentation literatureReferenceID="Nomenclature for Chromatography">The number of theoretical Plates                    per column using the variance method.                </Documentation>                <Quantity name="Plate Number">                    <Unit label="n">                        <SIUnit factor="1" exponent="-1">1</SIUnit>                    </Unit>                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Plates per Meter" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>The number of theoretical Plates per Meter N[1/m], where the distance is the length of                    the column.                </Documentation>                <Quantity name="Theoretical Plates per Meter">                    <Unit label="N">                        <SIUnit factor="1" exponent="-1">m</SIUnit> <!-- might be an Agilent specific item -->                    </Unit>                </Quantity>            </SeriesBlueprint><!-- this might be Agilent specific -->            <SeriesBlueprint name="Effective Theoretical Plate Number" seriesType="Numeric" modality="optional"                             dependency="dependent" plotScale="none">                <Documentation literatureReferenceID="Nomenclature for Chromatography">A number indicative of column                    performance when resolution is taken into account.                </Documentation>                <Quantity name="Effective Theoretical Plate Number">                    <Unit label="n">                        <SIUnit factor="1" exponent="-1">1</SIUnit>                    </Unit>                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Resolution Base" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="IUPAC Gold Book">The separation of two peaks in terms of their                    peak width at base (t R2 > t R1). In accordance with USP, ASTM, IUPAC.                </Documentation>                <Quantity name="Resolution">                    <Unit label="R">                        <SIUnit factor="1" exponent="1">1</SIUnit>                    </Unit>                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Resolution Half-Height" seriesType="Numeric" modality="optional"                             dependency="dependent" plotScale="none">                <Documentation literatureReferenceID="IUPAC Gold Book">The separation of two peaks in terms of their                    peak width at half of the height of the peak (t R2 > t R1).                </Documentation>                <Quantity name="Resolution">                    <Unit label="R">                        <SIUnit factor="1" exponent="1">1</SIUnit>                    </Unit>                </Quantity>            </SeriesBlueprint>            <SeriesBlueprint name="Asymmetry Factor" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="ASTM E1947-98">The peak asymmetry as measured by As=B/A, where A                    and B are the widths for the front and back parts of a peak measured at 10 % peak height. See                    also Tailing Factor.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Tailing Factor" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation literatureReferenceID="ASTM E1947-98">The peak asymmetry as measured by As=B/A, where A                    and B are the widths for the front and back parts of a peak measured at 5 % peak height (According                    to definition of the USP). Also termed Skewness.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Excess Kurtosis" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>Measures the shape of a peak. If the shape is identical to a normal distribution, it's                    excess is 0. A negative value resembles a flat, widespread peak; A positive value a sharp but narrow                    peak.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Signal-to-Noise Ratio" seriesType="Numeric" modality="optional"                             dependency="dependent" plotScale="none">                <Documentation>Signal-to-noise often is used to help determine the limit of detection or limit of                    quantification a specific method. Usually a portion of the signal will be regarded as noise in                    contrast to an actual signal. The Singal-To-Noise ratio describes the quality of the signal.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Variance" seriesType="Numeric" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>Peak Variance is a measure of lateral spreading.</Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Peak Type" seriesType="String" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>This is a textual description of the type of a peak's shape or other  properties (e.g. a shoulder or skimmed).                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Peak Number ISTD" seriesType="Int" modality="optional" dependency="dependency">                <Documentation>The number of the peak used as an internal standard.</Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Assignment ID" seriesType="String" modality="optional" plotScale="none"                             dependency="dependent">                <Documentation literatureReferenceID="JCAMP-DX LC-MS">Chemical structure assigned to this peak (use                    Substance ID)                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Assignment Formula" seriesType="String" modality="optional" plotScale="none"                             dependency="dependent">                <Documentation>Chemical formula assigned to this peak.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Assignment Compound" seriesType="String" modality="optional" plotScale="none"                             dependency="dependent">                <Documentation>Name of the chemical compound assigned to a peak.                </Documentation>            </SeriesBlueprint>            <SeriesBlueprint name="Assignment Type" seriesType="String" dependency="dependent" maxOccurs="unbounded" modality="optional" plotScale="none">                <Documentation>                    This series would contain references of analysis results like a confirmed compound or identified isomeres.                </Documentation>                <AllowedValue>                    <S>Target Substance</S>                </AllowedValue>                <AllowedValue>                    <S>Solvent Peak</S>                </AllowedValue>                <AllowedValue>                    <S>Isomere</S>                </AllowedValue>                <AllowedValue>                    <S>Impurity</S>                </AllowedValue>                <AllowedValue>                    <S>Unknown</S>                </AllowedValue>                <AllowedValue>                    <S>None</S>                </AllowedValue>            </SeriesBlueprint>            <SeriesBlueprint name="Comment" seriesType="String" modality="optional" dependency="dependent"                             plotScale="none">                <Documentation>Any information that doesn't fit the above mentioned categories maybe placed here.                </Documentation>            </SeriesBlueprint>        </SeriesSetBlueprint>    </ResultBlueprint>    <Bibliography>        <LiteratureReference literatureReferenceID="IUPAC Gold Book">IUPAC. Compendium of Chemical Terminology, 2nd ed.            (the "Gold Book"). Compiled by A. D. McNaught and A. Wilkinson. Blackwell Scientific Publications, Oxford            (1997). XML on-line corrected version: http://goldbook.iupac.org (2006-) created by M. Nic, J. Jirat, B.            Kosata; updates compiled by A. Jenkins. ISBN 0-9678550-9-8. doi:10.1351/goldbook.        </LiteratureReference>        <LiteratureReference literatureReferenceID="Nomenclature for Chromatography">Pure and Applied Chemistry. Volume            65, Issue 4, Pages 819–872, ISSN (Online) 1365-3075, ISSN (Print) 0033-4545, DOI: 10.1351/pac199365040819,            January 2009        </LiteratureReference>        <LiteratureReference literatureReferenceID="ASTM E1947-98">ASTM E1947-98; Standard Specification for Analytical            Data Interchange Protocol for Chromatographic Data        </LiteratureReference>        <LiteratureReference literatureReferenceID="USP 621 Chromatography">            https://hmc.usp.org/sites/default/files/documents/HMC/GCs-Pdfs/c621.pdf        </LiteratureReference>    </Bibliography></Technique>
+<?xml version="1.0" encoding="UTF-8"?>
+        <!-- edited by Patrick Boba(BSSN Software) -->
+        <!DOCTYPE Technique SYSTEM "animl_unit_entities.dtd">
+<Technique name="Chromatography Peak Table" version="0.90" xmlns="urn:org:astm:animl:schema:technique:draft:0.90"
+           xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xsi:schemaLocation="urn:org:astm:animl:schema:technique:draft:0.90 http://schemas.animl.org/current/animl-technique.xsd">
+    <Documentation>Peak table technique definition for a LC/GC time trace.</Documentation>
+    <ExperimentDataRoleBlueprint name="Calibration Table" experimentStepPurpose="consumed" modality="optional">
+        <Documentation>Calibration table with the results from related calibration runs.</Documentation>
+    </ExperimentDataRoleBlueprint>
+    <ExperimentDataRoleBlueprint name="Data Source" experimentStepPurpose="consumed" modality="optional">
+        <Documentation>Chromatogram from which this peak table was generated.</Documentation>
+    </ExperimentDataRoleBlueprint>
+    <MethodBlueprint>
+        <CategoryBlueprint name="Instrument Settings" modality="optional">
+            <Documentation>Variable characteristics or configuration parameters of the instrument.</Documentation>
+            <ParameterBlueprint name="Detector Offset" parameterType="Numeric" maxOccurs="1" modality="optional">
+                <Quantity name="time">
+                    &min; &s; &ms;
+                </Quantity>
+            </ParameterBlueprint>
+        </CategoryBlueprint>
+        <CategoryBlueprint name="Peak Detection" modality="optional">
+            <Documentation>Details on the used peak finding algorithm.</Documentation>
+            <ParameterBlueprint name="Algorithm Name" parameterType="String" modality="required">
+                <Documentation>The common name for the used algorithm.</Documentation>
+            </ParameterBlueprint>
+            <CategoryBlueprint name="Algorithm Parameters" modality="optional">
+                <Documentation>This section has to be handled by a vendor specific TechniqueExtension.</Documentation>
+            </CategoryBlueprint>
+        </CategoryBlueprint>
+        <CategoryBlueprint name="Baseline Detection" modality="optional">
+            <Documentation>Details on the used baseline detection algorithm.</Documentation>
+            <ParameterBlueprint name="Algorithm Name" parameterType="String" modality="required">
+                <Documentation>The common name for the used algorithm.</Documentation>
+            </ParameterBlueprint>
+            <CategoryBlueprint name="Algorithm Parameters" modality="optional">
+                <Documentation>This section has to be handled by a vendor specific TechniqueExtension.</Documentation>
+            </CategoryBlueprint>
+            <!-- is there a way to collect information on the baseline detection algorithm's parameters? -->
+        </CategoryBlueprint>
+        <CategoryBlueprint name="Peak Integration" modality="optional">
+            <Documentation>Details on the how the peak integration was performed.</Documentation>
+            <CategoryBlueprint name="Integration Algorithm" modality="optional">
+                <Documentation>The used integration algorithm.</Documentation>
+                <ParameterBlueprint name="Algorithm Name" parameterType="String">
+                    <Documentation>The common name for the used algorithm.</Documentation>
+                </ParameterBlueprint>
+                <CategoryBlueprint name="Algorithm Parameters" modality="optional">
+                    <Documentation>This section has to be handled by a vendor specific TechniqueExtension.
+                    </Documentation>
+                </CategoryBlueprint>
+            </CategoryBlueprint>
+            <CategoryBlueprint name="Skimming Algorithm" modality="optional">
+                <Documentation>If applicable, the used skimming algorithm.</Documentation>
+                <ParameterBlueprint name="Algorithm Name" parameterType="String" modality="required">
+                    <AllowedValue>
+                        <S>None</S>
+                    </AllowedValue>
+                    <AllowedValue>
+                        <S>Tangential</S>
+                    </AllowedValue>
+                    <AllowedValue>
+                        <S>Exponential</S>
+                    </AllowedValue>
+                    <AllowedValue>
+                        <S>Gaussian</S>
+                    </AllowedValue>
+                    <AllowedValue>
+                        <S>Valley to Valley</S>
+                    </AllowedValue>
+                    <AllowedValue>
+                        <S>Vertical Drop</S>
+                    </AllowedValue>
+                    <AllowedValue>
+                        <S>Other</S>
+                    </AllowedValue>
+                </ParameterBlueprint>
+                <CategoryBlueprint name="Algorithm Parameters" modality="optional">
+                    <Documentation>This section has to be handled by a vendor specific TechniqueExtension.
+                    </Documentation>
+                </CategoryBlueprint>
+            </CategoryBlueprint>
+        </CategoryBlueprint>
+        <CategoryBlueprint name="Filtering" modality="optional" maxOccurs="unbounded">
+            <Documentation>Filtering Step that was applied to the chromatogram prior to peak detection (e.g. smoothing
+                filters).
+            </Documentation>
+            <ParameterBlueprint name="Algorithm Name" parameterType="String" modality="required">
+                <Documentation>Details on the used filtering algorithm.</Documentation>
+            </ParameterBlueprint>
+            <CategoryBlueprint name="Algorithm Parameters" modality="optional">
+                <Documentation>This section has to be handled by a vendor specific TechniqueExtension.</Documentation>
+            </CategoryBlueprint>
+        </CategoryBlueprint>
+    </MethodBlueprint>
+    <ResultBlueprint name="Peak Table">
+        <SeriesSetBlueprint name="Peak Table">
+            <Documentation literatureReferenceID="USP 621 Chromatography">USP: "A peak is the portion of the
+                chromatographic
+                recording of the detector response when a single component
+                is eluted from the column. If separation is incomplete,
+                two or more components may be eluted as one unresolved peak." A peak table is a collection of peaks as
+                described before.
+            </Documentation>
+            <SeriesBlueprint name="Number" seriesType="Int" modality="required" dependency="independent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="ASTM E1947-98">Peak number identifying this particular peak. This
+                    is a running number.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="ID" seriesType="String" modality="optional" dependency="dependent" plotScale="none">
+                <Documentation literatureReferenceID="ASTM E1947-98">Peak identifier for this particular peak. This ID
+                    may be generated by the originating data system.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Group ID" seriesType="String" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>Identifier to assign a peak to a peak group along different detector channels of a single
+                    injection.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Name" seriesType="String" dependency="dependent" plotScale="none" maxOccurs="1" modality="optional">
+                <Documentation>A descriptive name of the peak (e.g. "Solvent Peak", "Target Substance", etc.).</Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Retention Time" seriesType="Numeric" modality="required" plotScale="none"
+                             dependency="dependent">
+                <Documentation literatureReferenceID="IUPAC Gold Book">Position on x axis where the peak maximum
+                    appears.
+                </Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Adjusted Retention Time" seriesType="Numeric" modality="optional" plotScale="none"
+                             dependency="dependent">
+                <Documentation literatureReferenceID="USP 621 Chromatography">Adjusted retention time of a component
+                    relative to that of another used as a reference.
+                </Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Start Time" seriesType="Numeric" modality="optional" plotScale="none"
+                             dependency="dependent">
+                <Documentation>Beginning of a peak</Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="End Time" seriesType="Numeric" modality="optional" plotScale="none"
+                             dependency="dependent">
+                <Documentation>End of a peak.</Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Value" seriesType="Numeric" modality="required" dependency="dependent"
+                             plotScale="none">
+                <Documentation>The peak's intensity at the peak apex.</Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Start Value" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>The peak's intensity at the peak start time.</Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="End Value" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>The peak's intensity at the peak end time.</Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+
+            <SeriesBlueprint name="Inflection Point Front Time" seriesType="Numeric" dependency="dependent"
+                             modality="optional" plotScale="none">
+                <Documentation>The x-coordinate of the inflection point of the front side of the peak.</Documentation>
+                <Quantity name="time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Inflection Point Front Value" seriesType="Numeric" dependency="dependent"
+                             modality="optional" plotScale="none">
+                <Documentation>The y-coordinate (= intensity) of the inflection point of the front side of the peak.
+                </Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Inflection Point Rear Time" seriesType="Numeric" dependency="dependent"
+                             modality="optional" plotScale="none">
+                <Documentation>The x-coordinate of the inflection point of the rear side of the peak.</Documentation>
+                <Quantity name="time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Inflection Point Rear Value" seriesType="Numeric" dependency="dependent"
+                             modality="optional" plotScale="none">
+                <Documentation>The y-coordinate (= intensity) of the inflection point of the rear side of the peak.
+                </Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+
+            <SeriesBlueprint name="Baseline Start Time" seriesType="Numeric" modality="optional" plotScale="none"
+                             dependency="dependent" maxOccurs="1">
+                <Documentation>Beginning of the baseline of a peak</Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Baseline Start Value" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none" maxOccurs="1">
+                <Documentation literatureReferenceID="ASTM E1947-98">Starting value (= intensity) of the computed
+                    baseline for this
+                    peak; in a scaled data unit, the unit for this is the same as that of the ordinate variable.
+                </Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Baseline End Time" seriesType="Numeric" modality="optional" plotScale="none"
+                             dependency="dependent" maxOccurs="1">
+                <Documentation>End of the baseline of a peak.</Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Baseline End Value" seriesType="Numeric" modality="optional" dependency="dependent"
+                             maxOccurs="1" plotScale="none">
+                <Documentation literatureReferenceID="ASTM E1947-98">End value (= intensity) of the computed baseline
+                    for this
+                    peak; in a scaled data unit, the unit for this is the same as that of the ordinate variable.
+                </Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+
+            <SeriesBlueprint name="Width Half Height" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="IUPAC Gold Book">Peak width at half height (w_h).</Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Width Base" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="IUPAC Gold Book">Peak width at base (w_b) is the segment of the
+                    peak base intercepted by the tangents drawn to the inflection points on either side of the peak.
+                </Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Width Inflection Point" seriesType="Numeric" modality="optional"
+                             dependency="dependent" plotScale="none">
+                <Documentation literatureReferenceID="IUPAC Gold Book">Peak width at inflection points (w_i) is the
+                    length of the line drawn between the inflection points parallel to the peak base.
+                </Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Width at 5% Height" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>Peak width at 5% relative height of the peak.</Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Width at 10% Height" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>Peak width at 10% relative height of the peak.</Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+
+            <SeriesBlueprint name="Height" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="IUPAC Gold Book">The distance between the peak maximum and the
+                    peak base, measured in a direction parallel to the axis representing the detector response. Can be
+                    either absolute or relative with respect to all peaks noted here.
+                </Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Height Percent" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>The distance between the peak maximum and the peak base, measured in a direction parallel
+                    to the axis representing the detector response relative to all detected peaks.
+                </Documentation>
+                <Quantity name="Percent Intensity">
+                    &percent;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Height-To-Valley Front" seriesType="Numeric" modality="optional"
+                             dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="USP 621 Chromatography">The distance between the peak maximum and
+                    the valley to the left side of the apex, measured in a direction parallel
+                    to the axis representing the detector response. Can be either absolute or relative with respect to
+                    all peaks noted here
+                </Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Height-To-Valley Rear" seriesType="Numeric" modality="optional"
+                             dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="USP 621 Chromatography">The distance between the peak maximum and
+                    the valley to the right side of the apex, measured in a direction parallel
+                    to the axis representing the detector response. Can be either absolute or relative with respect to
+                    all peaks noted here
+                </Documentation>
+                <Quantity name="Intensity">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Counts">
+                    &counts;
+                </Quantity>
+                <Quantity name="Voltage">
+                    &mV;
+                </Quantity>
+                <Quantity name="Percent">
+                    &percent;
+                </Quantity>
+                <Quantity name="Absorbance">
+                    &A; &AU;
+                </Quantity>
+                <Quantity name="Transmittance">
+                    &T; &percentT;
+                </Quantity>
+                <Quantity name="Reflectance">
+                    &R; &percentR;
+                </Quantity>
+                <Quantity name="Arbitrary">
+                    &arbitrary;
+                </Quantity>
+                <Quantity name="Custom">
+                </Quantity>
+            </SeriesBlueprint>
+
+            <SeriesBlueprint name="Mean Retention Time" seriesType="Numeric" modality="optional" plotScale="none"
+                             dependency="dependent">
+                <Documentation>The center of gravity of a peak. This is not necessarily the same as the retention time,
+                    depending on the skewness of the peak.
+                </Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Relative Retention Time" seriesType="Numeric" modality="optional" plotScale="none"
+                             dependency="dependent">
+                <Documentation literatureReferenceID="USP 621 Chromatography">USP: "Also known as unadjusted relative
+                    retention. Comparisons in USP are normally
+                    made in terms of unadjusted relative retention, unless otherwise indicated."
+                </Documentation>
+                <Quantity name="Time">
+                    &min;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Relative Retention" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="USP 621 Chromatography">
+                    USP: "Is the ratio of the adjusted retention time of a component relative to that of another used as
+                    a reference under identical conditions.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Separation Factor" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="USP 621 Chromatography">
+                    USP: "The separation factor is the relative retention calculated for two adjacent peaks (by
+                    convention the value of the separation factor is always bigger then 1.)"
+                </Documentation>
+                <Quantity name="alpha">
+                    <Unit label='alpha'>
+                        <SIUnit exponent='1' factor='1'>1</SIUnit>
+                    </Unit>
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Retention Factor" seriesType="Numeric" dependency="dependent" modality="optional"
+                             plotScale="none">
+                <Documentation literatureReferenceID="Nomenclature for Chromatography">The retention factor k = (T_r -
+                    T_0) / T_0. T_r is the retention time of the peak and T_0 the void time. Maybe also termed 'Capacity
+                    Factor', 'Capacity Ratio', 'Retention Ratio' or 'Mass Distribution'.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Retention Volume" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="IUPAC Gold Book">Retention measurements (and measurements of
+                    hold-up volume and peak width) may be made in terms of times or chart distances as well as volumes.
+                    If flow and recorder speeds are constant, the volumes are directly proportional to the times and
+                    chart distances.
+                </Documentation>
+                <Quantity name="Volume">
+                    &mL;
+                </Quantity>
+            </SeriesBlueprint>
+
+            <!-- Unit for Area unclear. It depends on the units of the chromatogram. -->
+            <SeriesBlueprint name="Area" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="ASTM E1947-98">The area enclosed between the peak and the
+                    baseline.
+                </Documentation>
+                <Quantity name="Area">
+                    &arbitrary;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Area Corrected" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>The peak area after a correction like skimming or function fitting was performed.
+                </Documentation>
+                <Quantity name="Area">
+                    &arbitrary;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Area Percent" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="ASTM E1947-98">The area enclosed between the peak and the
+                    baseline. Can be either absolute or relative with respect to all peaks noted here
+                </Documentation>
+                <Quantity name="Area">
+                    &percent;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Amount" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>The amount is the area percent of the peak with respect to the injected volume or concentration.
+                </Documentation>
+                <Quantity name="Amount">
+                    &mg_per_mL;
+                    &mL_per_mL;
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Plate Number Half-Height" seriesType="Numeric" modality="optional"
+                             dependency="dependent" plotScale="none">
+                <Documentation literatureReferenceID="Nomenclature for Chromatography">The number of theoretical Plates
+                    per column using the half-width method (ASTM).
+                </Documentation>
+                <Quantity name="Plate Number">
+                    <Unit label="n">
+                        <SIUnit factor="1" exponent="-1">1</SIUnit>
+                    </Unit>
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Plate Number Base" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="Nomenclature for Chromatography">The number of theoretical Plates
+                    per column using the tangent method (USP, ASTM).
+                </Documentation>
+                <Quantity name="Plate Number">
+                    <Unit label="n">
+                        <SIUnit factor="1" exponent="-1">1</SIUnit>
+                    </Unit>
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Plate Number Variance" seriesType="Numeric" modality="optional"
+                             dependency="dependent" plotScale="none">
+                <Documentation literatureReferenceID="Nomenclature for Chromatography">The number of theoretical Plates
+                    per column using the variance method.
+                </Documentation>
+                <Quantity name="Plate Number">
+                    <Unit label="n">
+                        <SIUnit factor="1" exponent="-1">1</SIUnit>
+                    </Unit>
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Plates per Meter" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>The number of theoretical Plates per Meter N[1/m], where the distance is the length of
+                    the column.
+                </Documentation>
+                <Quantity name="Theoretical Plates per Meter">
+                    <Unit label="N">
+                        <SIUnit factor="1" exponent="-1">m</SIUnit> <!-- might be an Agilent specific item -->
+                    </Unit>
+                </Quantity>
+            </SeriesBlueprint><!-- this might be Agilent specific -->
+            <SeriesBlueprint name="Effective Theoretical Plate Number" seriesType="Numeric" modality="optional"
+                             dependency="dependent" plotScale="none">
+                <Documentation literatureReferenceID="Nomenclature for Chromatography">A number indicative of column
+                    performance when resolution is taken into account.
+                </Documentation>
+                <Quantity name="Effective Theoretical Plate Number">
+                    <Unit label="n">
+                        <SIUnit factor="1" exponent="-1">1</SIUnit>
+                    </Unit>
+                </Quantity>
+            </SeriesBlueprint>
+
+            <SeriesBlueprint name="Resolution Base" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="IUPAC Gold Book">The separation of two peaks in terms of their
+                    peak width at base (t R2 > t R1). In accordance with USP, ASTM, IUPAC.
+                </Documentation>
+                <Quantity name="Resolution">
+                    <Unit label="R">
+                        <SIUnit factor="1" exponent="1">1</SIUnit>
+                    </Unit>
+                </Quantity>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Resolution Half-Height" seriesType="Numeric" modality="optional"
+                             dependency="dependent" plotScale="none">
+                <Documentation literatureReferenceID="IUPAC Gold Book">The separation of two peaks in terms of their
+                    peak width at half of the height of the peak (t R2 > t R1).
+                </Documentation>
+                <Quantity name="Resolution">
+                    <Unit label="R">
+                        <SIUnit factor="1" exponent="1">1</SIUnit>
+                    </Unit>
+                </Quantity>
+            </SeriesBlueprint>
+
+            <SeriesBlueprint name="Asymmetry Factor" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="ASTM E1947-98">The peak asymmetry as measured by As=B/A, where A
+                    and B are the widths for the front and back parts of a peak measured at 10 % peak height. See
+                    also Tailing Factor.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Tailing Factor" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation literatureReferenceID="ASTM E1947-98">The peak asymmetry as measured by As=B/A, where A
+                    and B are the widths for the front and back parts of a peak measured at 5 % peak height (According
+                    to definition of the USP). Also termed Skewness.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Excess Kurtosis" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>Measures the shape of a peak. If the shape is identical to a normal distribution, it's
+                    excess is 0. A negative value resembles a flat, widespread peak; A positive value a sharp but narrow
+                    peak.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Signal-to-Noise Ratio" seriesType="Numeric" modality="optional"
+                             dependency="dependent" plotScale="none">
+                <Documentation>Signal-to-noise often is used to help determine the limit of detection or limit of
+                    quantification a specific method. Usually a portion of the signal will be regarded as noise in
+                    contrast to an actual signal. The Singal-To-Noise ratio describes the quality of the signal.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Variance" seriesType="Numeric" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>Peak Variance is a measure of lateral spreading.</Documentation>
+            </SeriesBlueprint>
+
+            <SeriesBlueprint name="Peak Type" seriesType="String" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>This is a textual description of the type of a peak's shape or other  properties (e.g. a shoulder or skimmed).
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Peak Number ISTD" seriesType="Int" modality="optional" dependency="dependency">
+                <Documentation>The number of the peak used as an internal standard.</Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Assignment ID" seriesType="String" modality="optional" plotScale="none"
+                             dependency="dependent">
+                <Documentation literatureReferenceID="JCAMP-DX LC-MS">Chemical structure assigned to this peak (use
+                    Substance ID)
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Assignment Formula" seriesType="String" modality="optional" plotScale="none"
+                             dependency="dependent">
+                <Documentation>Chemical formula assigned to this peak.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Assignment Compound" seriesType="String" modality="optional" plotScale="none"
+                             dependency="dependent">
+                <Documentation>Name of the chemical compound assigned to a peak.
+                </Documentation>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Assignment Type" seriesType="String" dependency="dependent" maxOccurs="unbounded" modality="optional" plotScale="none">
+                <Documentation>
+                    This series would contain references of analysis results like a confirmed compound or identified isomeres.
+                </Documentation>
+                <AllowedValue>
+                    <S>Target Substance</S>
+                </AllowedValue>
+                <AllowedValue>
+                    <S>Solvent Peak</S>
+                </AllowedValue>
+                <AllowedValue>
+                    <S>Isomere</S>
+                </AllowedValue>
+                <AllowedValue>
+                    <S>Impurity</S>
+                </AllowedValue>
+                <AllowedValue>
+                    <S>Unknown</S>
+                </AllowedValue>
+                <AllowedValue>
+                    <S>None</S>
+                </AllowedValue>
+            </SeriesBlueprint>
+            <SeriesBlueprint name="Comment" seriesType="String" modality="optional" dependency="dependent"
+                             plotScale="none">
+                <Documentation>Any information that doesn't fit the above mentioned categories maybe placed here.
+                </Documentation>
+            </SeriesBlueprint>
+        </SeriesSetBlueprint>
+    </ResultBlueprint>
+    <Bibliography>
+        <LiteratureReference literatureReferenceID="IUPAC Gold Book">IUPAC. Compendium of Chemical Terminology, 2nd ed.
+            (the "Gold Book"). Compiled by A. D. McNaught and A. Wilkinson. Blackwell Scientific Publications, Oxford
+            (1997). XML on-line corrected version: http://goldbook.iupac.org (2006-) created by M. Nic, J. Jirat, B.
+            Kosata; updates compiled by A. Jenkins. ISBN 0-9678550-9-8. doi:10.1351/goldbook.
+        </LiteratureReference>
+        <LiteratureReference literatureReferenceID="Nomenclature for Chromatography">Pure and Applied Chemistry. Volume
+            65, Issue 4, Pages 819–872, ISSN (Online) 1365-3075, ISSN (Print) 0033-4545, DOI: 10.1351/pac199365040819,
+            January 2009
+        </LiteratureReference>
+        <LiteratureReference literatureReferenceID="ASTM E1947-98">ASTM E1947-98; Standard Specification for Analytical
+            Data Interchange Protocol for Chromatographic Data
+        </LiteratureReference>
+        <LiteratureReference literatureReferenceID="USP 621 Chromatography">
+            https://hmc.usp.org/sites/default/files/documents/HMC/GCs-Pdfs/c621.pdf
+        </LiteratureReference>
+    </Bibliography>
+</Technique>


### PR DESCRIPTION
Currently the chromatography-peak-table uses macintosh line endings (\r) while all other atdd files using windows-line endings (\r\n). And while the xml processing tools don't complain, at least the github UI shows strange red `^M` characters

Beside that there was an erroneous attribute in the specification the xml-validation of this technique fails with:

> SAXParseException; systemId: chromatography-peak-table.atdd; lineNumber: 770; columnNumber: 114; cvc-enumeration-valid: Value 'dependency' is not facet-valid with respect to enumeration '[independent, dependent]'. It must be a value from the enumeration.