### PR TITLE
ENTITY kg_per_mol has wrong label

### DIFF
--- a/animl_unit_entities.dtd
+++ b/animl_unit_entities.dtd
@@ -115,7 +115,7 @@
 
         <!-- Molar mass -->
         <!ENTITY g_per_mol "<Unit label='g/mol'><SIUnit exponent='1' factor='1e-3'>kg</SIUnit><SIUnit exponent='-1' factor='1'>mol</SIUnit></Unit>">
-        <!ENTITY kg_per_mol "<Unit label='g/mol'><SIUnit exponent='1' factor='1'>kg</SIUnit><SIUnit exponent='-1' factor='1'>mol</SIUnit></Unit>">
+        <!ENTITY kg_per_mol "<Unit label='kg/mol'><SIUnit exponent='1' factor='1'>kg</SIUnit><SIUnit exponent='-1' factor='1'>mol</SIUnit></Unit>">
 
         <!ENTITY reciprocal_cm "<Unit label='1/cm'><SIUnit exponent='-1' factor='1e-2'>m</SIUnit></Unit>">
         <!ENTITY reciprocal_um "<Unit label='1/um'><SIUnit exponent='-1' factor='1e-6'>m</SIUnit></Unit>">


### PR DESCRIPTION
Currently the `kg_per_mol` entity is labeled as `g/mol`