### PR TITLE
Add method name to TCD trace definition

### DIFF
--- a/tcd-trace.atdd
+++ b/tcd-trace.atdd
@@ -11,6 +11,9 @@
     <MethodBlueprint>
         <CategoryBlueprint name="Method Description" modality="optional">
             <Documentation>Basic contextual information about the measurement method.</Documentation>
+            <ParameterBlueprint name="Method Name" parameterType="String" modality="optional">
+                <Documentation>Name of the method used for the measurement.</Documentation>
+            </ParameterBlueprint>
             <ParameterBlueprint name="Method Reference" parameterType="String" modality="optional">
                 <Documentation>External reference to measurement method.</Documentation>
             </ParameterBlueprint>


### PR DESCRIPTION
Currently for TCD traces the method can only hold an external reference but this is not very user-friendly and often it is more convent to show the method name instead.

This adds an (optional) method name to the method description as it is already the case for the FID trace.

@burkhardschaefer can you review/merge this?