### PR TITLE
Add "mol/L" as a Quantity to the Amount of peaktable

### DIFF
--- a/chromatography-peak-table.atdd
+++ b/chromatography-peak-table.atdd
@@ -648,6 +648,7 @@
                 <Quantity name="Amount">
                     &mg_per_mL;
                     &mL_per_mL;
+                    &mol_per_L;
                 </Quantity>
             </SeriesBlueprint>
             <SeriesBlueprint name="Plate Number Half-Height" seriesType="Numeric" modality="optional"


### PR DESCRIPTION
"mol/L" is a commonly used amount to express the Quantity and therefore should be part of the list of quantities.

@burkhardschaefer can you review/merge?