### PR TITLE
Fix quantity name mismatches in ATDD files

### DIFF
--- a/chromatography.atdd
+++ b/chromatography.atdd
@@ -1218,7 +1218,7 @@ CONTROL METHOD
 					</Documentation>
 					<SeriesBlueprint name="Pressure Change Rate" seriesType="Float" dependency="dependent" plotScale="none">
 						<Documentation literatureReferenceID="Ettre PAC">Use for pressure programming – a procedure in which the inlet pressure of the mobile phase is changed systematically during a part or whole of the separation. </Documentation>
-						<Quantity name="Pressure">
+						<Quantity name="Pressure Change Rate">
 							&Pa_per_min; &psig_per_min; &bar_per_min;
 						</Quantity>
 					</SeriesBlueprint>

--- a/ecd-trace.atdd
+++ b/ecd-trace.atdd
@@ -155,7 +155,7 @@
             </ParameterBlueprint>
             <ParameterBlueprint name="Current to Voltage Conversion Factor" parameterType="Float" modality="optional">
                 <Documentation>Gain factor on the conversion from current to voltage.</Documentation>
-                <Quantity name="Factor"> &A_per_V; </Quantity>
+                <Quantity name="Electrical Conductance"> &A_per_V; </Quantity>
             </ParameterBlueprint>
             <ParameterBlueprint name="Offset Current" parameterType="Float" modality="optional">
                 <Documentation>Bucking (zero adjustment) current to remove background ions, applied before current-to-voltage conversion.</Documentation>

--- a/fid-trace.atdd
+++ b/fid-trace.atdd
@@ -105,7 +105,7 @@
             </ParameterBlueprint>
             <ParameterBlueprint name="Current to Voltage Conversion Factor" parameterType="Float" modality="optional">
                 <Documentation>Gain factor on the conversion from current to voltage.</Documentation>
-                <Quantity name="Factor"> &A_per_V; </Quantity>
+                <Quantity name="Electrical Conductance"> &A_per_V; </Quantity>
             </ParameterBlueprint>
             <ParameterBlueprint name="Offset Current" parameterType="Float" modality="optional">
                 <Documentation>Bucking (zero adjustment) current to remove background ions, applied before current-to-voltage conversion.</Documentation>

--- a/fpd-trace.atdd
+++ b/fpd-trace.atdd
@@ -100,7 +100,7 @@
             </ParameterBlueprint>
             <ParameterBlueprint name="Current to Voltage Conversion Factor" parameterType="Float" modality="optional">
                 <Documentation>Gain factor on the conversion from current to voltage.</Documentation>
-                <Quantity name="Factor"> &A_per_V; </Quantity>
+                <Quantity name="Electrical Conductance"> &A_per_V; </Quantity>
             </ParameterBlueprint>
             <ParameterBlueprint name="Offset Current" parameterType="Float" modality="optional">
                 <Documentation>Bucking (zero adjustment) current to remove background ions, applied before current-to-voltage conversion.</Documentation>

--- a/npd-trace.atdd
+++ b/npd-trace.atdd
@@ -159,7 +159,7 @@
             </ParameterBlueprint>
             <ParameterBlueprint name="Current to Voltage Conversion Factor" parameterType="Float" modality="optional">
                 <Documentation>Gain factor on the conversion from current to voltage.</Documentation>
-                <Quantity name="Factor"> &A_per_V; </Quantity>
+                <Quantity name="Electrical Conductance"> &A_per_V; </Quantity>
             </ParameterBlueprint>
             <ParameterBlueprint name="Offset Current" parameterType="Float" modality="optional">
                 <Documentation>Bucking (zero adjustment) current to remove background ions, applied before current-to-voltage conversion.</Documentation>


### PR DESCRIPTION
- chromatography.atdd: Change "Pressure" to "Pressure Change Rate" for Pressure Change Rate SeriesBlueprint (line 1221)
- fid-trace.atdd, ecd-trace.atdd, fpd-trace.atdd, npd-trace.atdd: Change "Factor" to "Electrical Conductance" for Current to Voltage Conversion Factor parameters

These changes align quantity names with their dimensional nature as documented in animl_unit_entities.dtd